### PR TITLE
fix drones getting stuck deconstructing

### DIFF
--- a/script/companion.lua
+++ b/script/companion.lua
@@ -583,7 +583,7 @@ function Companion:set_speed(speed)
 
             local S_MIN  = 0.25   -- size at near-zero speeds
             local S_MAX  = 1.33   -- size cap at high speeds
-            local V_FULL = 0.11   -- v where scale ~~ 1.0 (˜5 tiles/s)
+            local V_FULL = 0.11   -- v where scale ~~ 1.0 (Â˜5 tiles/s)
             local SENS   = 10.0   -- speed of size rise over velocity
 
             local GAIN = (1.0 - S_MIN) / math.log(1 + SENS * V_FULL)
@@ -921,7 +921,7 @@ end
 function Companion:return_to_player()
 
     if not self.player.valid then return end
-    if self.is_busy_for_construction then return end
+    if self.is_busy_for_construction and not self.is_getting_full then return end
     if self.player.physical_surface ~= self.entity.surface then
         return
     end


### PR DESCRIPTION
Drones when assigned deconstruction of a lot of entities can end up with a full inventory and will not shove said inventory to the player.

this is just a simple fix there are a few other things that could be done to fix this issue as well, such as adding onto is_busy_for_construction, something that is not a fix for this but should probably be done eventually is change is_getting_full to use LuaInventory.count_empty_stacks() to track how full the inventory is rather than explicitly checking slot 16